### PR TITLE
only show batch for verification

### DIFF
--- a/src/components/contribute/setup/contribute.tsx
+++ b/src/components/contribute/setup/contribute.tsx
@@ -197,7 +197,9 @@ class Contribute extends React.Component<Props, State> {
                         <TypeSelect setType={this.selectType} />
                     ) : contributeType == 'tala' && !demographic ? (
                         <DemographicForm onSubmit={this.onDemographicsSubmit} />
-                    ) : labels.length > 0 && !selectedBatch ? (
+                    ) : labels.length > 0 &&
+                      !selectedBatch &&
+                      contributeType != 'tala' ? (
                         <BatchSelect
                             labels={labels}
                             setLabel={this.onSelectBatch}


### PR DESCRIPTION
Bug for superusers

Super user had to choose a batch even when contribution type was tala. This created behavior where the user had clips for verification that the user could overwrite.