### PR TITLE
hotfix, can't skip sentence during recording

### DIFF
--- a/src/components/contribute/carousel/wheel.tsx
+++ b/src/components/contribute/carousel/wheel.tsx
@@ -371,7 +371,9 @@ class CarouselWheel extends React.Component<Props, State> {
     };
 
     handleSkip = async () => {
-        await this.updateSentence(this.activeIndex, { removed: true });
+        if (!this.recorder?.isRecording) {
+            await this.updateSentence(this.activeIndex, { removed: true });
+        }
     };
 
     handleDeleteClip = async () => {


### PR DESCRIPTION
This fixes an issue where you could skip a sentence you are currently recording.