### PR TITLE
Tag herma clips

### DIFF
--- a/src/components/contribute/carousel/wheel.tsx
+++ b/src/components/contribute/carousel/wheel.tsx
@@ -618,8 +618,10 @@ class CarouselWheel extends React.Component<Props, State> {
 
     handleUpload = async (i: number): Promise<void> => {
         const clip = this.state.clips[i];
-        const { user } = this.props;
-        uploadClip(clip, user)
+        const { user, contributeType } = this.props;
+        const isRepeated = contributeType === ContributeType.REPEAT;
+
+        uploadClip(clip, user, isRepeated)
             .then((clipId: number) =>
                 this.updateClip(i, { clipId, uploaded: true })
             )

--- a/src/pages/api/contribute/upload.ts
+++ b/src/pages/api/contribute/upload.ts
@@ -49,6 +49,8 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         const sampleRate = parseInt(headers.sample_rate as string) || undefined;
         const duration = parseFloat(headers.duration as string) || undefined;
         const size = parseFloat(headers.size as string) || undefined;
+        const isRepeated =
+            decodeURIComponent(headers.is_repeated as string) || undefined;
 
         const clip: ClipMetadata = {
             age,
@@ -61,6 +63,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
             sampleRate: sampleRate && sampleRate,
             duration: duration && duration,
             size: size && size,
+            isRepeated: isRepeated === 'true',
         };
 
         const contentType = headers['content-type'] as string;

--- a/src/server/database/clips.ts
+++ b/src/server/database/clips.ts
@@ -161,6 +161,7 @@ export default class Clips {
             sampleRate,
             duration,
             size,
+            isRepeated,
         } = clip;
 
         try {
@@ -191,9 +192,9 @@ export default class Clips {
             const [row] = await this.sql.query(
                 `
                     INSERT INTO
-                        clips (client_id, path, sentence, original_sentence_id, sex, age, native_language, institution, user_agent, status, sample_rate, duration, size, dialect, speaker_id)
+                        clips (client_id, path, sentence, original_sentence_id, sex, age, native_language, institution, user_agent, status, sample_rate, duration, size, dialect, speaker_id, is_repeated)
                     VALUES
-                        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON DUPLICATE KEY UPDATE
                         created_at = NOW();
                 `,
@@ -213,6 +214,7 @@ export default class Clips {
                     size ? size : null,
                     dialect,
                     speaker_id,
+                    isRepeated ? 1 : 0,
                 ]
             );
             const { insertId } = row;

--- a/src/server/database/migrations/20210519170537-add-is-repeat.js
+++ b/src/server/database/migrations/20210519170537-add-is-repeat.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+    dbm = options.dbmigrate;
+    type = dbm.dataType;
+    seed = seedLink;
+};
+
+exports.up = async function (db) {
+    return db.runSql(`
+    ALTER TABLE
+      clips
+    ADD COLUMN is_repeat TINYINT(1) DEFAULT NULL
+  `);
+};
+
+exports.down = function () {
+    return null;
+};
+
+exports._meta = {
+    version: 1,
+};

--- a/src/server/database/sentences.ts
+++ b/src/server/database/sentences.ts
@@ -194,8 +194,6 @@ export default class Sentences {
                         sentences (id, text, is_used, source, clip_path)
                     VALUES
                         (?, ?, ?, ?, ?)
-                    ON DUPLICATE KEY UPDATE
-                        is_used = VALUES(is_used), clip_path = VALUES(clip_path)
                 `,
                 [originalSentenceId, sentence, true, packageName, path]
             );

--- a/src/server/middlewares/batch-upload.ts
+++ b/src/server/middlewares/batch-upload.ts
@@ -57,6 +57,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
                         status,
                         sentence,
                         userAgent: 'undefined',
+                        isRepeated: false,
                     };
 
                     const audioFile = findMatchingAudioFile(audio, file);

--- a/src/server/middlewares/sentences-with-clips-upload.ts
+++ b/src/server/middlewares/sentences-with-clips-upload.ts
@@ -61,7 +61,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
                 0
             );
             console.log(
-                `${count} sentences with clips uploaded with source label ${packageName}`
+                `${count}/${sentenceIds.length} sentences with clips uploaded with source label ${packageName}`
             );
             return res.status(200).json(count);
         } catch (error) {

--- a/src/services/contribute-api.ts
+++ b/src/services/contribute-api.ts
@@ -113,6 +113,7 @@ export const fetchClipsToRepeat = async (
 export interface UploadClipRequest {
     clip: WheelClip;
     user: UserState;
+    isRepeated: boolean;
 }
 
 export const uploadClip = async (

--- a/src/services/contribute-api.ts
+++ b/src/services/contribute-api.ts
@@ -117,7 +117,8 @@ export interface UploadClipRequest {
 
 export const uploadClip = async (
     clip: WheelClip,
-    user: UserState
+    user: UserState,
+    isRepeated: boolean
 ): Promise<number> => {
     const endpoint = '/api/contribute/upload';
 
@@ -145,6 +146,7 @@ export const uploadClip = async (
             sample_rate: recording.sampleRate,
             duration: recording.duration,
             size: recording.blob?.size,
+            is_repeated: encodeURIComponent(isRepeated),
         },
         data: recording.blob,
     })

--- a/src/store/contribute/epics.ts
+++ b/src/store/contribute/epics.ts
@@ -16,7 +16,8 @@ export const uploadClipEpic: Epic<
             from(
                 api.contribute.uploadClip(
                     action.payload.clip,
-                    action.payload.user
+                    action.payload.user,
+                    action.payload.isRepeated
                 )
             ).pipe(
                 map(uploadClip.success),

--- a/src/types/samples.ts
+++ b/src/types/samples.ts
@@ -26,6 +26,7 @@ export interface ClipMetadata {
     sampleRate?: number;
     duration?: number;
     size?: number;
+    isRepeated: boolean;
 }
 
 export interface WheelClip extends Clip {


### PR DESCRIPTION
This does two things:

1. When uploading clips for herma, we are no longer replacing existing sentences. Instead when that happens an error is thrown which is handled and lets the user know that that sentence is not uploaded, sort of. The user will see how many was uploaded correctly.
2. Add support for the is_repeated column in the clips table in the db. This involved updating api and components