### PR TITLE
restet gaming and contribute in store when switching from continue

### DIFF
--- a/src/components/contribute/continue/continue-buttons.tsx
+++ b/src/components/contribute/continue/continue-buttons.tsx
@@ -153,6 +153,7 @@ class ContinueButtons extends React.Component<Props, State> {
         const {
             contribute: { expanded },
             setGaming,
+            resetContribute,
         } = this.props;
         if (!expanded) {
             return;
@@ -161,12 +162,13 @@ class ContinueButtons extends React.Component<Props, State> {
             contribute: { goal },
             router,
         } = this.props;
+        setGaming(false);
+        resetContribute();
         if (goal && goal.contributeType == 'hlusta') {
             router.push(pages.speak);
         } else {
             router.push(pages.listen);
         }
-        setGaming(false);
     };
 
     render() {

--- a/src/components/contribute/setup/contribute.tsx
+++ b/src/components/contribute/setup/contribute.tsx
@@ -181,7 +181,13 @@ class Contribute extends React.Component<Props, State> {
     };
 
     skipTips = () => {
-        this.props.setGaming(true);
+        const {
+            contribute: { goal, gaming },
+            setGaming,
+        } = this.props;
+        if (goal && !gaming) {
+            setGaming(true);
+        }
     };
 
     onSelectBatch = (selectedBatch: string) => {


### PR DESCRIPTION
This should fix the ugly ui when choosing a new contribution type.

To reproduce:
- Do a contribution (reading/verifying 1 sentence is enough)
- Click senda in
- Select the blue option
- ![image](https://user-images.githubusercontent.com/72071258/119119487-c1e72880-ba1a-11eb-8f37-031a97047dad.png)
- It should now have correct format, and the options should not be squeezed to the top.
