### PR TITLE
Fix NaN stats

### DIFF
--- a/src/components/contribute/continue/continue-buttons.tsx
+++ b/src/components/contribute/continue/continue-buttons.tsx
@@ -18,6 +18,8 @@ import {
 } from '../../../constants/packages';
 import { ContributeType, Goal } from '../../../types/contribute';
 import takathatt from '../../../pages/takathatt';
+import contribute from '../setup/contribute';
+import { capitalizeFirstLetter } from '../../../utilities/string-helper';
 
 const ContinueButtonsContainer = styled.div`
     width: 100%;
@@ -154,7 +156,7 @@ class ContinueButtons extends React.Component<Props, State> {
      * Switches the context (from speak to listen or vice verse.)
      * and re-routes the user to the contribution amount selection.
      */
-    handleSwitch = () => {
+    handleSwitch = async (switchTo: string) => {
         const {
             contribute: { expanded },
             setGaming,
@@ -163,17 +165,24 @@ class ContinueButtons extends React.Component<Props, State> {
         if (!expanded) {
             return;
         }
-        const {
-            contribute: { goal },
-            router,
-        } = this.props;
+        const { router } = this.props;
+        console.log(`switch to: ${switchTo}`);
+        switch (switchTo.toLowerCase()) {
+            case ContributeType.SPEAK:
+                console.log(`switching to: speak`);
+                await router.push(pages.speak);
+                break;
+            case ContributeType.LISTEN:
+                console.log(`switching to: listen`);
+                await router.push(pages.listen);
+                break;
+            case ContributeType.REPEAT:
+                console.log(`switching to: repeat`);
+                await router.push(pages.repeat);
+                break;
+        }
         setGaming(false);
         resetContribute();
-        if (goal && goal.contributeType == 'hlusta') {
-            router.push(pages.speak);
-        } else {
-            router.push(pages.listen);
-        }
     };
 
     getGoals = (): Goal[] => {
@@ -194,12 +203,29 @@ class ContinueButtons extends React.Component<Props, State> {
         }
     };
 
-    render() {
-        const { shouldContinue } = this.state;
+    getButtonsText = (): string[] => {
         const {
             contribute: { goal },
         } = this.props;
+        const tala = capitalizeFirstLetter(ContributeType.SPEAK);
+        const hlusta = capitalizeFirstLetter(ContributeType.LISTEN);
+        const herma = capitalizeFirstLetter(ContributeType.REPEAT);
+        switch (goal!.contributeType) {
+            case ContributeType.SPEAK:
+                return [hlusta, herma, `${tala} meira`];
+            case ContributeType.LISTEN:
+                return [tala, herma, `${hlusta} meira`];
+            case ContributeType.REPEAT:
+                return [tala, hlusta, `${herma} meira`];
+            default:
+                return ['', '', ''];
+        }
+    };
+
+    render() {
+        const { shouldContinue } = this.state;
         const goals = this.getGoals();
+        const buttons = this.getButtonsText();
         return (
             <ContinueButtonsContainer>
                 <MessageContainer>
@@ -213,15 +239,21 @@ class ContinueButtons extends React.Component<Props, State> {
                     <ButtonsContainer position={shouldContinue ? -1 : 0}>
                         <ButtonContainer
                             color={'blue'}
-                            onClick={this.handleSwitch}
+                            onClick={() => this.handleSwitch(buttons[0])}
                         >
-                            <>{'Taka þátt'}</>
+                            <>{buttons[0]}</>
+                        </ButtonContainer>
+                        <ButtonContainer
+                            color={'blue'}
+                            onClick={() => this.handleSwitch(buttons[1])}
+                        >
+                            <>{buttons[1]}</>
                         </ButtonContainer>
                         <ButtonContainer
                             color={'green'}
                             onClick={this.handleContinue}
                         >
-                            <>Halda áfram</>
+                            <>{buttons[2]}</>
                         </ButtonContainer>
                     </ButtonsContainer>
                     <ButtonsContainer position={shouldContinue ? 0 : 1}>

--- a/src/components/contribute/continue/continue-buttons.tsx
+++ b/src/components/contribute/continue/continue-buttons.tsx
@@ -166,23 +166,19 @@ class ContinueButtons extends React.Component<Props, State> {
             return;
         }
         const { router } = this.props;
-        console.log(`switch to: ${switchTo}`);
+        setGaming(false);
+        resetContribute();
         switch (switchTo.toLowerCase()) {
             case ContributeType.SPEAK:
-                console.log(`switching to: speak`);
                 await router.push(pages.speak);
                 break;
             case ContributeType.LISTEN:
-                console.log(`switching to: listen`);
                 await router.push(pages.listen);
                 break;
             case ContributeType.REPEAT:
-                console.log(`switching to: repeat`);
                 await router.push(pages.repeat);
                 break;
         }
-        setGaming(false);
-        resetContribute();
     };
 
     getGoals = (): Goal[] => {

--- a/src/components/contribute/continue/continue-buttons.tsx
+++ b/src/components/contribute/continue/continue-buttons.tsx
@@ -11,8 +11,13 @@ import {
     setExpanded,
     setGaming,
 } from '../../../store/contribute/actions';
-import { listenGoals, speakGoals } from '../../../constants/packages';
-import { Goal } from '../../../types/contribute';
+import {
+    listenGoals,
+    speakGoals,
+    repeatGoals,
+} from '../../../constants/packages';
+import { ContributeType, Goal } from '../../../types/contribute';
+import takathatt from '../../../pages/takathatt';
 
 const ContinueButtonsContainer = styled.div`
     width: 100%;
@@ -161,12 +166,26 @@ class ContinueButtons extends React.Component<Props, State> {
             contribute: { goal },
             router,
         } = this.props;
-        if (goal && goal.contributeType == 'hlusta') {
-            router.push(pages.speak);
-        } else {
-            router.push(pages.listen);
-        }
+        router.push(pages.contribute);
         setGaming(false);
+    };
+
+    getGoals = (): Goal[] => {
+        const {
+            contribute: { goal },
+        } = this.props;
+
+        switch (goal?.contributeType) {
+            case ContributeType.SPEAK:
+                return speakGoals;
+            case ContributeType.LISTEN:
+                return listenGoals;
+            case ContributeType.REPEAT:
+                return repeatGoals;
+            default:
+                // if nothing found, assume speak goals
+                return speakGoals;
+        }
     };
 
     render() {
@@ -174,8 +193,7 @@ class ContinueButtons extends React.Component<Props, State> {
         const {
             contribute: { goal },
         } = this.props;
-        const goals =
-            goal && goal.contributeType == 'tala' ? speakGoals : listenGoals;
+        const goals = this.getGoals();
         return (
             <ContinueButtonsContainer>
                 <MessageContainer>
@@ -191,11 +209,7 @@ class ContinueButtons extends React.Component<Props, State> {
                             color={'blue'}
                             onClick={this.handleSwitch}
                         >
-                            <>
-                                {goal && goal.contributeType == 'hlusta'
-                                    ? 'Lesa inn'
-                                    : 'Yfirfara'}
-                            </>
+                            <>{'Taka þátt'}</>
                         </ButtonContainer>
                         <ButtonContainer
                             color={'green'}

--- a/src/components/contribute/continue/continue.tsx
+++ b/src/components/contribute/continue/continue.tsx
@@ -105,19 +105,25 @@ class ContinueModal extends React.Component<Props, State> {
 
     getProgressToday = () => {
         const {
-            contribute: { goal },
+            contribute: { goal, totalSpoken, totalVerified },
             stats: { weekly },
         } = this.props;
         const contributeType = goal?.contributeType;
 
         switch (contributeType) {
             case ContributeType.SPEAK:
-                return weekly.clips[weekly.clips.length - 1]?.count;
+                return (
+                    weekly.clips[weekly.clips.length - 1]?.count + totalSpoken
+                );
             case ContributeType.REPEAT:
                 // TODO: add specific stats for repeat
-                return weekly.clips[weekly.clips.length - 1]?.count;
+                return (
+                    weekly.clips[weekly.clips.length - 1]?.count + totalSpoken
+                );
             case ContributeType.LISTEN:
-                return weekly.votes[weekly.votes.length - 1]?.count;
+                return (
+                    weekly.votes[weekly.votes.length - 1]?.count + totalVerified
+                );
             default:
                 return 0;
         }
@@ -148,8 +154,7 @@ class ContinueModal extends React.Component<Props, State> {
                 </ChartContainer>
                 <StatsMessageContainer>
                     <StatsMessage>
-                        Árangur dagsins eru{' '}
-                        <span>{progressToday + (goal?.count || 0)}</span>{' '}
+                        Árangur dagsins eru <span>{progressToday}</span>{' '}
                         setningar.
                     </StatsMessage>
                 </StatsMessageContainer>

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -7,6 +7,7 @@ export const pages = {
     contribute: '/takathatt',
     listen: '/hlusta',
     speak: '/tala',
+    repeat: '/herma',
     dashboard: '/minar-sidur',
     login: '/innskraning',
 };

--- a/src/store/contribute/reducer.ts
+++ b/src/store/contribute/reducer.ts
@@ -3,6 +3,7 @@ import { ContributeState } from './state';
 import * as ContributeActions from './actions';
 
 import { speakGoals } from '../../constants/packages';
+import { ContributeType } from '../../types/contribute';
 
 const initialState: ContributeState = {
     expanded: false,
@@ -53,6 +54,8 @@ export default createReducer(initialState)
         return {
             ...initialState,
             gaming: state.gaming,
+            totalSpoken: state.totalSpoken,
+            totalVerified: state.totalVerified,
         };
     })
     .handleAction(ContributeActions.setExpanded, (state, action) => {
@@ -62,14 +65,22 @@ export default createReducer(initialState)
         };
     })
     .handleAction(ContributeActions.incrementProgress, (state, action) => {
+        const addToSpoken =
+            state.goal && state.goal.contributeType !== ContributeType.LISTEN;
         return {
             ...state,
             progress: state.progress + 1,
+            totalSpoken: state.totalSpoken + (addToSpoken ? 1 : 0),
+            totalVerified: state.totalVerified + (addToSpoken ? 0 : 1),
         };
     })
     .handleAction(ContributeActions.decrementProgress, (state, action) => {
+        const removeFromSpoken =
+            state.goal && state.goal.contributeType !== ContributeType.LISTEN;
         return {
             ...state,
             progress: state.progress - 1,
+            totalSpoken: state.totalSpoken - (removeFromSpoken ? 1 : 0),
+            totalVerified: state.totalVerified - (removeFromSpoken ? 0 : 1),
         };
     });

--- a/src/utilities/string-helper.ts
+++ b/src/utilities/string-helper.ts
@@ -1,0 +1,3 @@
+export const capitalizeFirstLetter = (text: string): string => {
+    return text[0].toUpperCase() + text.substring(1);
+};


### PR DESCRIPTION
This also allows the user to select, Tala, Hlusta, Herma on the continue screen.
I also let the store track totalSpoken and totalVerified by updating those values when updating progress.

I realize that I'm solving a lot of the cases for: if Herma do that, if Tala do this if Hlusta do the other thing with switch cases and putting the alternative texts into arrays.

If you know of a prettier/intuitive solution, I'm all ears! (mostly related to continue-buttons.tsx)