### PR TITLE
Optimize batch selection

### DIFF
--- a/src/components/contribute/setup/batch-select.tsx
+++ b/src/components/contribute/setup/batch-select.tsx
@@ -62,10 +62,14 @@ interface Props {
 
 export const BatchSelect: React.FunctionComponent<Props> = (props) => {
     const { labels, setLabel } = props;
+    // Add samromur to labels if not existing
+    const fullLabels = labels.some((label) => label === 'samromur')
+        ? labels
+        : ['samromur', ...labels];
 
     return (
         <CardGrid>
-            {labels.map((label: string, i: number) => (
+            {fullLabels.map((label: string, i: number) => (
                 <CardContainer key={i} onClick={() => setLabel(label)}>
                     <PlayIcon height={40} width={40} fill={'gray'} />
                     <Title>

--- a/src/components/contribute/setup/contribute.tsx
+++ b/src/components/contribute/setup/contribute.tsx
@@ -106,7 +106,7 @@ class Contribute extends React.Component<Props, State> {
                 client: { isSuperUser },
             },
         } = this.props;
-        if (isSuperUser) {
+        if (isSuperUser && window.location.pathname === '/hlusta') {
             const labels = await adminApi.fetchVerificationBatches();
             this.setState({
                 labels: labels.filter((label) => label !== null),
@@ -224,6 +224,11 @@ class Contribute extends React.Component<Props, State> {
                     )}
                     {!contributeType ? (
                         <TypeSelect setType={this.selectType} />
+                    ) : labels.length > 0 && !selectedBatch ? (
+                        <BatchSelect
+                            labels={labels}
+                            setLabel={this.onSelectBatch}
+                        />
                     ) : !goal ? (
                         <PackageSelect
                             contributeType={contributeType}
@@ -233,13 +238,6 @@ class Contribute extends React.Component<Props, State> {
                           contributeType === ContributeType.REPEAT) &&
                       !demographic ? (
                         <DemographicForm onSubmit={this.onDemographicsSubmit} />
-                    ) : labels.length > 0 &&
-                      !selectedBatch &&
-                      contributeType == ContributeType.LISTEN ? (
-                        <BatchSelect
-                            labels={labels}
-                            setLabel={this.onSelectBatch}
-                        />
                     ) : !gaming ? (
                         client.skipTips ? (
                             this.skipTips()

--- a/src/server/database/clips.ts
+++ b/src/server/database/clips.ts
@@ -364,6 +364,8 @@ export default class Clips {
                 FROM
                     clips
                 WHERE
+                    status not in ('pybossa', 'samromur')
+                AND
                     NOT EXISTS (
                         SELECT
                             *


### PR DESCRIPTION
After the summer students started using samromur I saw that a db query was taking up all the cpu from the database on amazon. 

This branch optimizes it and only runs it when required.

The optimization is very simple, the count(*) was very heavy when all the clips where included in the search, filtering out the standard dataset 'samromur' from the query made it manageable. 

I instead add the default dataset as an option in labels in the frontend.