### PR TITLE
make labels a property, fetch it in initalProps before rendering hlusta

### DIFF
--- a/src/components/contribute/setup/contribute.tsx
+++ b/src/components/contribute/setup/contribute.tsx
@@ -80,7 +80,6 @@ type Props = ReturnType<typeof mapStateToProps> &
 interface State {
     batchClips?: WheelClip[];
     contributeType?: ContributeType;
-    //labels: string[];
     demographic: boolean;
     tips: boolean;
     selectedBatch?: string;

--- a/src/components/contribute/setup/contribute.tsx
+++ b/src/components/contribute/setup/contribute.tsx
@@ -69,6 +69,7 @@ interface ContributeProps {
     groupedSentences?: AllGroupsSentences;
     contributeType?: ContributeType;
     clipsToRepeat?: WheelClip[];
+    labels?: string[];
 }
 
 type Props = ReturnType<typeof mapStateToProps> &
@@ -79,7 +80,7 @@ type Props = ReturnType<typeof mapStateToProps> &
 interface State {
     batchClips?: WheelClip[];
     contributeType?: ContributeType;
-    labels: string[];
+    //labels: string[];
     demographic: boolean;
     tips: boolean;
     selectedBatch?: string;
@@ -93,26 +94,11 @@ class Contribute extends React.Component<Props, State> {
 
         this.state = {
             contributeType: this.props.contributeType,
-            labels: [],
             demographic: false,
             tips: false,
             clipsToRepeat: this.props.clipsToRepeat,
         };
     }
-
-    componentDidMount = async () => {
-        const {
-            user: {
-                client: { isSuperUser },
-            },
-        } = this.props;
-        if (isSuperUser && window.location.pathname === '/hlusta') {
-            const labels = await adminApi.fetchVerificationBatches();
-            this.setState({
-                labels: labels.filter((label) => label !== null),
-            });
-        }
-    };
 
     getBatchClips = async (selectedBatch: string) => {
         const {
@@ -129,14 +115,10 @@ class Contribute extends React.Component<Props, State> {
     };
 
     getInstruction = (): string => {
-        const {
-            contributeType,
-            demographic,
-            labels,
-            selectedBatch,
-        } = this.state;
+        const { contributeType, demographic, selectedBatch } = this.state;
         const {
             contribute: { goal },
+            labels,
         } = this.props;
         if (!contributeType) {
             return 'Taka þátt';
@@ -152,7 +134,7 @@ class Contribute extends React.Component<Props, State> {
             } else {
                 return goal
                     ? 'Góð ráð við yfirferð'
-                    : labels.length > 0 && !selectedBatch
+                    : labels && labels.length > 0 && !selectedBatch
                     ? 'Hvaða yfirferðarflokk viltu hlusta á?'
                     : 'Veldu pakka';
             }
@@ -200,7 +182,6 @@ class Contribute extends React.Component<Props, State> {
             contributeType,
             demographic,
             tips,
-            labels,
             selectedBatch,
             batchClips,
             sentences,
@@ -211,6 +192,7 @@ class Contribute extends React.Component<Props, State> {
             clips,
             contribute: { expanded, gaming, goal },
             user: { client },
+            labels,
         } = this.props;
 
         return (
@@ -224,7 +206,7 @@ class Contribute extends React.Component<Props, State> {
                     )}
                     {!contributeType ? (
                         <TypeSelect setType={this.selectType} />
-                    ) : labels.length > 0 && !selectedBatch ? (
+                    ) : labels && labels.length > 0 && !selectedBatch ? (
                         <BatchSelect
                             labels={labels}
                             setLabel={this.onSelectBatch}
@@ -260,7 +242,6 @@ class Contribute extends React.Component<Props, State> {
                             sentences={sentences}
                             clipsToRepeat={repeatedClips}
                             contributeType={contributeType}
-                            // Add a sentencesAndclips attribute here?
                         />
                     )}
                 </ContributeContainer>

--- a/src/pages/hlusta.tsx
+++ b/src/pages/hlusta.tsx
@@ -16,12 +16,15 @@ import { saveVote } from '../services/contribute-api';
 import ContributePage from '../components/contribute/setup/contribute';
 import { ContributeType } from '../types/contribute';
 
+import { fetchVerificationBatches } from '../services/admin-api';
+
 const dispatchProps = {
     resetContribute,
 };
 
 interface InitialProps {
     initialClips: Clip[];
+    labels: string[];
 }
 
 type Props = ReturnType<typeof mapStateToProps> &
@@ -43,6 +46,15 @@ class SpeakPage extends React.Component<Props, State> {
     static async getInitialProps(ctx: NextPageContext) {
         const { isServer, req, res, store } = ctx;
 
+        const isSuper = store.getState().user.client.isSuperUser;
+        let labels: string[] = [];
+
+        if (isSuper) {
+            labels = await fetchVerificationBatches();
+            // filter out null labels
+            labels = labels.filter((label) => label !== null);
+        }
+
         // Reset session progress
         store.dispatch(resetContribute());
 
@@ -60,16 +72,18 @@ class SpeakPage extends React.Component<Props, State> {
         return {
             namespacesRequired: ['common'],
             initialClips,
+            labels,
         };
     }
 
     render() {
-        const { initialClips } = this.props;
+        const { initialClips, labels } = this.props;
 
         return (
             <ContributePage
                 contributeType={ContributeType.LISTEN}
                 clips={initialClips}
+                labels={labels}
             />
         );
     }


### PR DESCRIPTION
I noticed that we can have a weird behavior,
that after you click hlusta, you first get to see the select package size screen, then it switches to the select verification package.

This moves the responsibility for fetching the labels purely to the hlusta page.
With finds them and sends them as a property to Contribute.

Now after pressing hlusta, the loading icon should show until the labels have also been fetched.