### PR TITLE
fix instructions bug

### DIFF
--- a/src/components/contribute/carousel/instructions.tsx
+++ b/src/components/contribute/carousel/instructions.tsx
@@ -86,13 +86,15 @@ const InstructionsFC: React.FC<Props> = ({
     };
 
     const speakInstructions = (): React.ReactNode => {
+        const { hasPlayedRepeatClip, goal } = contribute;
         return audioError ? (
             <Error>{getAudioErrorMessage()}</Error>
         ) : recordingError ? (
             <Error>{getRecordingErrorMessage()}</Error>
         ) : activeClip ? (
             <Message>Smelltu á örina til að spila upptökuna</Message>
-        ) : contribute.hasPlayedRepeatClip ? (
+        ) : hasPlayedRepeatClip ||
+          goal?.contributeType !== ContributeType.REPEAT ? (
             <Message>Smelltu á hljóðnemann og lestu setninguna upp</Message>
         ) : (
             <Message>Hlustaðu á upptökuna </Message>

--- a/src/components/contribute/carousel/instructions.tsx
+++ b/src/components/contribute/carousel/instructions.tsx
@@ -5,6 +5,7 @@ import { UploadError, WheelClip } from '../../../types/samples';
 import { connect } from 'react-redux';
 import { RootState } from 'typesafe-actions';
 import { setHasPlayedRepeatClip } from '../../../store/contribute/actions';
+import { ContributeType } from '../../../types/contribute';
 
 const InstructionsContainer = styled.div`
     width: 100%;


### PR DESCRIPTION
The updated instructions for herma broke the instructions for tala
This remedies that.

Before on tala:
Started with instructions to listen to clip

Now:
Starts with correct instruction to click the recordicon to record the sentence