### PR TITLE
check if undefined instead of value

### DIFF
--- a/src/components/contribute/carousel/wheel.tsx
+++ b/src/components/contribute/carousel/wheel.tsx
@@ -555,7 +555,7 @@ class CarouselWheel extends React.Component<Props, State> {
             vote: clip.vote as ClipVote,
             voteId: clip.voteId,
         };
-        if (!clip.voteId) {
+        if (clip.voteId === undefined) {
             this.props.incrementProgress();
         }
 


### PR DESCRIPTION
This prevents the user from getting infinite progress by
In Hlusta
Play clip,
Vote
Play same clip again
Vote the same vote
Repeat to above steps for infinite progress, this is now prevented.

The issue was an if statement not checking a truthy value instead of the checking if there is a value or not.