### PR TITLE
Add actual herma stats

### DIFF
--- a/src/components/charts/continue-chart.tsx
+++ b/src/components/charts/continue-chart.tsx
@@ -41,7 +41,7 @@ export const ContinueChart: React.FunctionComponent<Props> = ({
             case ContributeType.LISTEN:
                 return stats.votes;
             case ContributeType.REPEAT:
-                return stats.clips;
+                return stats.repeatClips;
             default:
                 return [];
         }

--- a/src/components/contribute/continue/continue.tsx
+++ b/src/components/contribute/continue/continue.tsx
@@ -105,7 +105,7 @@ class ContinueModal extends React.Component<Props, State> {
 
     getProgressToday = () => {
         const {
-            contribute: { goal, totalSpoken, totalVerified },
+            contribute: { goal, totalSpoken, totalRepeated, totalVerified },
             stats: { weekly },
         } = this.props;
         const contributeType = goal?.contributeType;
@@ -116,9 +116,9 @@ class ContinueModal extends React.Component<Props, State> {
                     weekly.clips[weekly.clips.length - 1]?.count + totalSpoken
                 );
             case ContributeType.REPEAT:
-                // TODO: add specific stats for repeat
                 return (
-                    weekly.clips[weekly.clips.length - 1]?.count + totalSpoken
+                    weekly.repeatClips[weekly.repeatClips.length - 1]?.count +
+                    totalRepeated
                 );
             case ContributeType.LISTEN:
                 return (

--- a/src/pages/herma.tsx
+++ b/src/pages/herma.tsx
@@ -5,7 +5,7 @@ import { RootState } from 'typesafe-actions';
 import Contribute from '../components/contribute/setup/contribute';
 import { fetchClipsToRepeat } from '../services/contribute-api';
 import { resetContribute } from '../store/contribute/actions';
-import { fetchWeeklyClips } from '../store/stats/actions';
+import { fetchWeeklyRepeatedClips } from '../store/stats/actions';
 import { ContributeType } from '../types/contribute';
 import { Clip } from '../types/samples';
 import makeSSRDispatch from '../utilities/ssr-request';
@@ -28,8 +28,7 @@ class RepeatPage extends React.Component<Props> {
         store.dispatch(resetContribute());
 
         // // Fetch some stats to display at the end of the session
-        //TODO: make this work for SSR dispatch
-        makeSSRDispatch(ctx, fetchWeeklyClips.request);
+        makeSSRDispatch(ctx, fetchWeeklyRepeatedClips.request);
 
         // Fetch clips to prompt the user with
         const host = isServer && req ? 'http://' + req.headers.host : undefined;

--- a/src/server/database/stats.ts
+++ b/src/server/database/stats.ts
@@ -21,9 +21,6 @@ export default class Clips {
         const table = ['tala', 'herma'].includes(contributeType)
             ? 'clips'
             : 'votes';
-        const isRepeat = contributeType == ContributeType.REPEAT;
-        console.log(contributeType);
-        console.log(table);
         const [rows] = await this.sql.query(
             `
                 SELECT

--- a/src/server/database/stats.ts
+++ b/src/server/database/stats.ts
@@ -2,6 +2,7 @@ import Sql from './sql';
 import { TimelineStat } from '../../types/stats';
 import { IndividualStat, SchoolStat } from '../../types/competition';
 import lazyCache from '../lazy-cache';
+import { ContributeType } from '../../types/contribute';
 
 const cacheTimeMS = 1000 * 60 * 10; // 10 minutes
 const cacheTimeMSLong = 100 * 60 * 60; // 1 hour
@@ -17,11 +18,16 @@ export default class Clips {
     fetchWeeklyStats = lazyCache(async (contributeType: string): Promise<
         TimelineStat[]
     > => {
-        const table = contributeType == 'tala' ? 'clips' : 'votes';
+        const table = ['tala', 'herma'].includes(contributeType)
+            ? 'clips'
+            : 'votes';
+        const isRepeat = contributeType == ContributeType.REPEAT;
+        console.log(contributeType);
+        console.log(table);
         const [rows] = await this.sql.query(
             `
                 SELECT
-                    COUNT(${table}.id) as count,
+                    COUNT(res.id) as count,
                     DATE(cal.date) as date
                 FROM (
                     SELECT SUBDATE(NOW(), INTERVAL 6 DAY) + INTERVAL xc DAY AS date
@@ -35,9 +41,15 @@ export default class Clips {
                         ) xxc1
                     ) cal
                 LEFT JOIN
-                    ${table}
+                    (select * from ${table} 
+                    ${
+                        contributeType == 'tala'
+                            ? 'WHERE is_repeated = 0'
+                            : contributeType == 'herma' &&
+                              'WHERE is_repeated = 1'
+                    }) as res
                 ON
-                    DATE(${table}.created_at) = DATE(cal.date)
+                    DATE(res.created_at) = DATE(cal.date)
                 WHERE
                     cal.date <= NOW()
                 GROUP BY

--- a/src/services/stats-api.ts
+++ b/src/services/stats-api.ts
@@ -22,6 +22,24 @@ export const fetchWeeklyClips = async (
         });
 };
 
+export const fetchWeeklyRepeatClips = async (
+    payload: SSRRequest
+): Promise<TimelineStat[]> => {
+    const endpoint = `/api/stats/weekly?type=herma`;
+    const url = payload.host ? payload.host + endpoint : endpoint;
+    return axios({
+        method: 'GET',
+        url,
+    })
+        .then((response: AxiosResponse) => {
+            return response.data;
+        })
+        .catch((error: AxiosError) => {
+            console.error(error);
+            return Promise.reject(error.code);
+        });
+};
+
 export const fetchWeeklyVotes = async (
     payload: SSRRequest
 ): Promise<TimelineStat[]> => {

--- a/src/store/contribute/reducer.ts
+++ b/src/store/contribute/reducer.ts
@@ -10,6 +10,7 @@ const initialState: ContributeState = {
     gaming: false,
     progress: 0,
     totalSpoken: 0,
+    totalRepeated: 0,
     totalVerified: 0,
     hasPlayedRepeatClip: false,
 };
@@ -56,6 +57,7 @@ export default createReducer(initialState)
             gaming: state.gaming,
             totalSpoken: state.totalSpoken,
             totalVerified: state.totalVerified,
+            totalRepeated: state.totalRepeated,
         };
     })
     .handleAction(ContributeActions.setExpanded, (state, action) => {
@@ -65,22 +67,39 @@ export default createReducer(initialState)
         };
     })
     .handleAction(ContributeActions.incrementProgress, (state, action) => {
-        const addToSpoken =
-            state.goal && state.goal.contributeType !== ContributeType.LISTEN;
+        const { isSpeak, isListen, isRepeat } = getContributeType(state);
         return {
             ...state,
             progress: state.progress + 1,
-            totalSpoken: state.totalSpoken + (addToSpoken ? 1 : 0),
-            totalVerified: state.totalVerified + (addToSpoken ? 0 : 1),
+            totalSpoken: state.totalSpoken + (isSpeak ? 1 : 0),
+            totalVerified: state.totalVerified + (isListen ? 1 : 0),
+            totalRepeated: state.totalRepeated + (isRepeat ? 1 : 0),
         };
     })
     .handleAction(ContributeActions.decrementProgress, (state, action) => {
-        const removeFromSpoken =
-            state.goal && state.goal.contributeType !== ContributeType.LISTEN;
+        const { isSpeak, isListen, isRepeat } = getContributeType(state);
         return {
             ...state,
             progress: state.progress - 1,
-            totalSpoken: state.totalSpoken - (removeFromSpoken ? 1 : 0),
-            totalVerified: state.totalVerified - (removeFromSpoken ? 0 : 1),
+            totalSpoken: state.totalSpoken - (isSpeak ? 1 : 0),
+            totalVerified: state.totalVerified - (isListen ? 1 : 0),
+            totalRepeated: state.totalRepeated - (isRepeat ? 1 : 0),
         };
     });
+
+// Helper function for the increment/decrement functions to find the contribute type
+const getContributeType = (
+    state: ContributeState
+): { isSpeak: boolean; isListen: boolean; isRepeat: boolean } => {
+    const isSpeak = !!(
+        state.goal && state.goal.contributeType == ContributeType.SPEAK
+    );
+    const isListen = !!(
+        state.goal && state.goal.contributeType == ContributeType.LISTEN
+    );
+    const isRepeat = !!(
+        state.goal && state.goal.contributeType == ContributeType.REPEAT
+    );
+
+    return { isSpeak, isListen, isRepeat };
+};

--- a/src/store/contribute/state.ts
+++ b/src/store/contribute/state.ts
@@ -6,6 +6,7 @@ export interface ContributeState {
     goal?: Goal;
     progress: number;
     totalSpoken: number;
+    totalRepeated: number;
     totalVerified: number;
     hasPlayedRepeatClip: boolean;
 }

--- a/src/store/stats/actions.ts
+++ b/src/store/stats/actions.ts
@@ -46,3 +46,8 @@ export const fetchTodayClips = createAsyncAction(
 )<SSRRequest, number, string>();
 
 //TODO: add fetchWeeklyRepeatedClips action
+export const fetchWeeklyRepeatedClips = createAsyncAction(
+    'FETCH_WEEKLY_REPEAT_CLIPS_REQUEST',
+    'FETCH_WEEKLY_REPEAT_CLIPS_SUCCESS',
+    'FETCH_WEEKLY_REPEAT_CLIPS_FAILED'
+)<SSRRequest, TimelineStat[], string>();

--- a/src/store/stats/epics.ts
+++ b/src/store/stats/epics.ts
@@ -22,6 +22,24 @@ export const fetchWeeklyClipsEpic: Epic<
         )
     );
 
+export const fetchWeeklyRepeatedClipsEpic: Epic<
+    RootAction,
+    RootAction,
+    RootState,
+    Services
+> = (action$, state$, { api }) =>
+    action$.pipe(
+        filter(isActionOf(statsActions.fetchWeeklyRepeatedClips.request)),
+        switchMap((action) =>
+            from(api.stats.fetchWeeklyRepeatClips(action.payload)).pipe(
+                map(statsActions.fetchWeeklyRepeatedClips.success),
+                catchError((message: string) =>
+                    of(statsActions.fetchWeeklyRepeatedClips.failure(message))
+                )
+            )
+        )
+    );
+
 export const fetchWeeklyVotesEpic: Epic<
     RootAction,
     RootAction,

--- a/src/store/stats/reducer.ts
+++ b/src/store/stats/reducer.ts
@@ -11,6 +11,7 @@ const initialState: StatsState = {
     weekly: {
         clips: [],
         votes: [],
+        repeatClips: [],
     },
 };
 
@@ -71,4 +72,16 @@ export default createReducer(initialState)
             ...state,
             todayClips: action.payload,
         };
-    });
+    })
+    .handleAction(
+        StatsActions.fetchWeeklyRepeatedClips.success,
+        (state, action) => {
+            return {
+                ...state,
+                weekly: {
+                    ...state.weekly,
+                    repeatClips: action.payload,
+                },
+            };
+        }
+    );

--- a/src/store/stats/state.ts
+++ b/src/store/stats/state.ts
@@ -9,5 +9,6 @@ export interface StatsState {
     weekly: {
         clips: TimelineStat[];
         votes: TimelineStat[];
+        repeatClips: TimelineStat[];
     };
 }


### PR DESCRIPTION
Previous on the screen that pops up when clicking Senda in, the stats for herma were the same as the stats for tala.

Now herma and tala should have their own stats.