### PR TITLE
remove empty clips from fetch verification labels

### DIFF
--- a/src/server/database/clips.ts
+++ b/src/server/database/clips.ts
@@ -377,6 +377,8 @@ export default class Clips {
                             client_id = ?)
                     AND
                         is_valid is null
+                    AND
+                        empty = 0
                     GROUP BY
                         status
                 ) AS res


### PR DESCRIPTION
I see that when clips have been marked empty, they still counted when looking for verification labels that needed votes. This caused the verification packs for boys to still be visible when it was empty.