### PR TITLE
Acessability improvements to get to contribution

### DIFF
--- a/src/components/contribute/carousel/controls/main-controls.tsx
+++ b/src/components/contribute/carousel/controls/main-controls.tsx
@@ -504,6 +504,12 @@ class MainControls extends React.Component<Props, State> {
                                     ? this.handleStopRecording
                                     : this.handleStartRecording
                             }
+                            tabIndex={0}
+                            title={
+                                !isPlaying
+                                    ? 'Smelltu á hljóðnemann og lestu setninguna upp (spacebar)'
+                                    : 'Smelltu á örina til að spila upptökuna (spacebar)'
+                            }
                         >
                             {!isRecording ? (
                                 <MicIcon

--- a/src/components/contribute/carousel/controls/repeat-clip-play-button.tsx
+++ b/src/components/contribute/carousel/controls/repeat-clip-play-button.tsx
@@ -121,7 +121,12 @@ const RepeatClipPlayButton: React.FunctionComponent<Props> = (props) => {
 
     return (
         //show stop button while playing repeated clip and stop button when playing clip
-        <PlayButton onClick={handleTogglePlay} isActive={props.isActive}>
+        <PlayButton
+            onClick={handleTogglePlay}
+            isActive={props.isActive}
+            title={'Hlustaðu á upptökuna (A)'}
+            tabIndex={0}
+        >
             <RelativePlayIconContainer>
                 {isPlaying ? (
                     <PauseIcon height={35} width={35} fill={'green'} />

--- a/src/components/contribute/setup/consent-form.tsx
+++ b/src/components/contribute/setup/consent-form.tsx
@@ -15,9 +15,13 @@ import validateEmail from '../../../utilities/validate-email';
 
 import { ageFromKennitala } from '../../../utilities/kennitala-helper';
 
-const ConsentFormContainer = styled.div`
+interface ConsentFormContainerProps {
+    active: boolean;
+}
+
+const ConsentFormContainer = styled.div<ConsentFormContainerProps>`
     width: 100%;
-    display: grid;
+    display: ${({ active }) => (active ? 'grid' : 'none')};
     gap: 1rem;
     grid-template-columns: 1fr 1fr;
     ${({ theme }) => theme.media.small} {
@@ -230,8 +234,9 @@ class ConsentForm extends React.Component<Props, State> {
         const submittable = !emailPrompt
             ? kennitala.length == 10
             : validateEmail(email);
+        const { visible } = this.props;
         return (
-            <ConsentFormContainer>
+            <ConsentFormContainer active={visible}>
                 <Instructions>
                     {emailSent ? (
                         <React.Fragment>

--- a/src/components/contribute/setup/demographic-form.tsx
+++ b/src/components/contribute/setup/demographic-form.tsx
@@ -73,14 +73,14 @@ interface SubmitButtonProps {
     disabled: boolean;
 }
 
-const SubmitButton = styled.div<SubmitButtonProps>`
+const SubmitButton = styled.button<SubmitButtonProps>`
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-
     font-weight: 600;
     font-size: 1.1rem;
+    border: none;
     border-radius: 0.1rem;
     padding: 1rem 2rem;
     background-color: ${({ disabled, theme }) =>
@@ -418,6 +418,7 @@ class DemographicForm extends React.Component<Props, State> {
                 <ConsentAndSwitchUserContainer
                     active={hasConsent}
                     isCompetition={this.isCompetition()}
+                    tabIndex={hasConsent ? 0 : -1}
                 >
                     <ConsentMessage>Leyfi staðfest</ConsentMessage>
                     <SwitchUser onClick={this.switchUser}>

--- a/src/components/contribute/setup/package-card.tsx
+++ b/src/components/contribute/setup/package-card.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { Goal } from '../../../types/contribute';
 
-const CardContainer = styled.div`
+const CardContainer = styled.button`
     display: flex;
     flex-direction: column;
+    align-items: center;
     position: relative;
     padding: 1rem;
     background-color: white;

--- a/src/components/contribute/setup/tips/tips.tsx
+++ b/src/components/contribute/setup/tips/tips.tsx
@@ -18,12 +18,12 @@ const TipsContainer = styled.div`
     }
 `;
 
-const SkipButton = styled.div`
+const SkipButton = styled.button`
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-
+    border: none;
     font-weight: 600;
     font-size: 1.1rem;
     border-radius: 0.1rem;

--- a/src/components/contribute/setup/type-select.tsx
+++ b/src/components/contribute/setup/type-select.tsx
@@ -25,7 +25,7 @@ interface CardContainerProps {
     disabled?: boolean;
 }
 
-const CardContainer = styled.div<CardContainerProps>`
+const CardContainer = styled.button<CardContainerProps>`
     display: grid;
     grid-template-columns: 2.5rem auto;
     gap: 1.5rem;

--- a/src/components/layout/header/navigation.tsx
+++ b/src/components/layout/header/navigation.tsx
@@ -15,9 +15,8 @@ interface NavLinkProps {
 const NavLink = styled.a<NavLinkProps>`
     cursor: pointer;
     color: ${({ theme, isActive }) => isActive && theme.colors.red} !important;
-    &: hover {
-        color: ${({ theme, isActive }) =>
-            isActive && theme.colors.red} !important;
+    &:hover {
+        color: ${({ theme }) => theme.colors.darkerBlue} !important;
     }
 `;
 
@@ -94,25 +93,25 @@ export const Navigation: React.FunctionComponent<Props> = (props) => {
     return (
         <NavigationContainer {...props}>
             <NavigationLinks {...props}>
-                <Link href="/">
+                <Link href="/" passHref>
                     <NavLink isActive={pathname == '/'}>Forsíða</NavLink>
                 </Link>
-                <Link href="/takathatt">
+                <Link href="/takathatt" passHref>
                     <NavLink isActive={pathname == '/takathatt'}>
                         Taka þátt
                     </NavLink>
                 </Link>
-                <Link href="/grunnskolakeppni">
+                <Link href="/grunnskolakeppni" passHref>
                     <NavLink isActive={pathname == '/grunnskolakeppni'}>
                         Grunnskólakeppni
                     </NavLink>
                 </Link>
-                <Link href="/gagnasafn">
+                <Link href="/gagnasafn" passHref>
                     <NavLink isActive={pathname == '/gagnasafn'}>
                         Gagnasafnið
                     </NavLink>
                 </Link>
-                <Link href="/um">
+                <Link href="/um" passHref>
                     <NavLink isActive={pathname == '/um'}>Um Samróm</NavLink>
                 </Link>
                 <NavLink

--- a/src/components/ui/input/checkbox.tsx
+++ b/src/components/ui/input/checkbox.tsx
@@ -18,7 +18,11 @@ const CheckboxContainer = styled.div<CheckProps>`
     border: 2px solid
         ${({ active, theme }) => (active ? 'black' : theme.colors.borderGray)};
 
-    & :hover {
+    &:hover {
+        border: 2px solid black;
+    }
+
+    &:focus-within {
         border: 2px solid black;
     }
 `;

--- a/src/components/ui/input/dropdown.tsx
+++ b/src/components/ui/input/dropdown.tsx
@@ -17,6 +17,7 @@ const DropdownButtonContainer = styled.div<DropdownProps>`
     & :active,
     :focus {
         outline: none;
+        border-color: red;
     }
 `;
 
@@ -30,7 +31,7 @@ const DropdownSelect = styled.select`
     -moz-appearance: none;
     & :active,
     :focus {
-        outline: none;
+        outline: 3px solid;
     }
     padding: 1rem;
     cursor: pointer;

--- a/src/components/ui/input/dropdown.tsx
+++ b/src/components/ui/input/dropdown.tsx
@@ -17,7 +17,6 @@ const DropdownButtonContainer = styled.div<DropdownProps>`
     & :active,
     :focus {
         outline: none;
-        border-color: red;
     }
 `;
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -165,8 +165,9 @@ interface ButtonProps {
     color: string;
 }
 
-const CTAButton = styled.div<ButtonProps>`
+const CTAButton = styled.button<ButtonProps>`
     flex: 1;
+    border: none;
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
Adds better support for navigating the site with keyboard.

Focusing on the process to get to Herma contribution.

On the herma page I've added tab support and titles for the play record buttons, but the keyboard shortcuts and mouseclicks are the only way to activate them.

This is a good start for now. There are some additional components that would be good to improve accessibility while contributing. (Information, delete recording, the numbers, the text in the help page). But get to come later