### PR TITLE
add links and descriptions to available data sets.

### DIFF
--- a/public/static/locales/eng/the-database.json
+++ b/public/static/locales/eng/the-database.json
@@ -9,9 +9,9 @@
         "middle": "The database consists of sentences and audio clips from the reading of those sentences as well as metadata. Each entry in the database contains FLAC audio clips and the corresponding text file.",
         "preface-releases": "There are currently three releases of data sets from Samrómur.",
         "samromur-21-05": "This is the first release of the data from the Samrómur collection. The corpus contains 100,000 (145 hours) validated speech-recordings in Icelandic, available both on <2>Clarin</2> and <6>OpenSLR</6>",
-        "samromur-children": "This release of data from the Samrómur collection focuses on children (4-17 years old). It contains more than 137.000 (131 hours) of validated speech recordings uttered by children in Icelandic, available both on <2>Clarin</2> and <6>OpenSLR</6>.",
+        "samromur-children": "This release of data from the Samrómur collection focuses on children (4-17 years old). It contains more than 137,000 (131 hours) of validated speech recordings uttered by children in Icelandic, available both on <2>Clarin</2> and <6>OpenSLR</6>.",
         "samromur-queries": "This release of data from the Samrómur collection focuses on queries. It contains 17,475 (20 hours) of validated speech-recordings in Icelandic,  available both on <2>Clarin</2> and <6>OpenSLR</6>.",
-        "sign-up-for-updates": "Subscribe to the newsletter below to be notified when further datasets becomes accessible."
+        "sign-up-for-updates": "Subscribe to the newsletter below to be notified when further data sets becomes accessible."
     },
     "age-gender-chart-title": "Recordings per age group and gender",
     "age-mother-tounge-chart-title": "Recordings per age group and native tongue",

--- a/public/static/locales/eng/the-database.json
+++ b/public/static/locales/eng/the-database.json
@@ -7,7 +7,11 @@
         "title": "The Samrómur database",
         "beginning": "Samrómur is an open and accessible database of voices that everyone is free to use when developing software in Icelandic.",
         "middle": "The database consists of sentences and audio clips from the reading of those sentences as well as metadata. Each entry in the database contains FLAC audio clips and the corresponding text file.",
-        "end": "The first release of 100,000 utterances has been released on <2>OpenSLR</2>. Subscribe to the newsletter below to be notified when further datasets becomes accessible."
+        "preface-releases": "There are currently three releases of data sets from Samrómur.",
+        "samromur-21-05": "This is the first release of the data from the Samrómur collection. The corpus contains 100,000 (145 hours) validated speech-recordings in Icelandic, available both on <2>Clarin</2> and <6>OpenSLR</6>",
+        "samromur-children": "This release of data from the Samrómur collection focuses on children (4-17 years old). It contains more than 137.000 (131 hours) of validated speech recordings uttered by children in Icelandic, available both on <2>Clarin</2> and <6>OpenSLR</6>.",
+        "samromur-queries": "This release of data from the Samrómur collection focuses on queries. It contains 17,475 (20 hours) of validated speech-recordings in Icelandic,  available both on <2>Clarin</2> and <6>OpenSLR</6>.",
+        "sign-up-for-updates": "Subscribe to the newsletter below to be notified when further datasets becomes accessible."
     },
     "age-gender-chart-title": "Recordings per age group and gender",
     "age-mother-tounge-chart-title": "Recordings per age group and native tongue",

--- a/public/static/locales/isl/the-database.json
+++ b/public/static/locales/isl/the-database.json
@@ -7,7 +7,11 @@
         "title": "Gagnasafnið Samrómur",
         "beginning": "Samrómur er opið og aðgengilegt gagnasafn radda sem öllum er frjálst að nýta við þróun hugbúnaðar á íslensku.",
         "middle": "Gagnasafnið samanstendur af setningum og hljóðbrotum af upplestri þeirra setninga ásamt lýsigögnum. Hver færsla í gagnasafninu inniheldur FLAC-hljóðbrot og samsvarandi textaskrá.",
-        "end": "Fyrsta gagnasafnið með 100.000 setningum hefur verið gefið út á <2>OpenSLR</2>. Skráðu þig á póstlistann hér fyrir neðan til þess að fá tilkynningu þegar fleiri gagnasöfn verða gerð aðgengileg."
+        "preface-releases": "Það eru þrjár útgáfur af gagnasöfnum frá Samróms.",
+        "samromur-21-05": "Þetta er fyrsta útgáfan af gögnum úr safni Samróms. Útgáfan inniheldur 100.000 (145 klst.) staðfestar talupptökur á íslensku, fáanlegar bæði á <2>Clarin</2> og <6>OpenSLR</6>",
+        "samromur-children": "Þessi útgáfa gagna úr safni Samróms einblínir á börn (4-17 ára). Útgáfan inniheldur 137.000 (131 klst.) staðfestar talupptökur frá börnum á íslensku, fáanlegar bæði á <2>Clarin</2> og <6>OpenSLR</6>.",
+        "samromur-queries": "Þessi útgáfa gagna úr safni Samróms einblínir á fyrirspurnir. Útgáfan inniheldur 17.475 (20 klst.) staðfestar talupptökur á íslensku, fáanlegar bæði á <2>Clarin</2> og <6>OpenSLR</6>.",
+        "sign-up-for-updates": "Skráðu þig á póstlistann hér fyrir neðan til þess að fá tilkynningu þegar fleiri gagnasöfn verða gerð aðgengileg."
     },
     "age-gender-chart-title": "Upptökur eftir aldri og kyni",
     "age-mother-tounge-chart-title": "Upptökur eftir aldri og móðurmáli",

--- a/src/components/dataset/about.tsx
+++ b/src/components/dataset/about.tsx
@@ -50,6 +50,12 @@ const AboutContainer = styled.div`
     font-size: 0.9rem;
 `;
 
+const Bold = styled.span`
+    font-weight: bold;
+`;
+
+const Dataset = styled.span``;
+
 interface Props {
     clips: number;
     clients: number;
@@ -92,21 +98,91 @@ export const AboutDataset: React.FunctionComponent<Props> = ({
                 <h2>{t('database.title')}</h2>
                 <span>{t('database.beginning')}</span>
                 <span>{t('database.middle')}</span>
-                <span>
-                    <Trans i18nKey={'database.end'} t={t}>
-                        Fyrsta gagnasafnið með 100.000 setningum hefur verið
-                        gefið út á{' '}
+                <span>{t('database.preface-releases')}</span>
+                <Dataset>
+                    <Bold>
+                        Samrómur 21.05
+                        <br />
+                    </Bold>
+                    <Trans i18nKey={'database.samromur-21-05'} t={t}>
+                        Þetta er fyrsta útgáfan af gögnum úr safni Samróms.
+                        Útgáfan inniheldur 100.000 (145 klst.) staðfestar
+                        talupptökur á íslensku, fáanlegar bæði ás{' '}
+                        <StyledLink
+                            target={'blank'}
+                            href={
+                                'https://repository.clarin.is/repository/xmlui/handle/20.500.12537/189'
+                            }
+                        >
+                            Clarin
+                        </StyledLink>{' '}
+                        og{' '}
                         <StyledLink
                             target={'blank'}
                             href={'https://www.openslr.org/112/'}
                         >
                             OpenSLR
                         </StyledLink>
-                        . Skráðu þig á póstlistann hér fyrir neðan til þess að
-                        fá tilkynningu þegar fleiri gagnasöfn verða gerð
-                        aðgengileg.
+                        .
                     </Trans>
-                </span>
+                </Dataset>
+                <Dataset>
+                    <Bold>
+                        Samrómur Children 21.09
+                        <br />
+                    </Bold>
+                    <Trans i18nKey={'database.samromur-children'} t={t}>
+                        Þessi útgáfa gagna úr safni Samróms einblínir á börn
+                        (4-17 ára). Útgáfan inniheldur 137.000 (131 klst.)
+                        staðfestar talupptökur frá börnum á íslensku, fáanlegar
+                        bæði á{' '}
+                        <StyledLink
+                            target={'blank'}
+                            href={
+                                'https://repository.clarin.is/repository/xmlui/handle/20.500.12537/185'
+                            }
+                        >
+                            Clarin
+                        </StyledLink>{' '}
+                        og{' '}
+                        <StyledLink
+                            target={'blank'}
+                            href={'https://www.openslr.org/117/'}
+                        >
+                            OpenSLR
+                        </StyledLink>
+                        .
+                    </Trans>
+                </Dataset>
+                <Dataset>
+                    <Bold>
+                        Samrómur Queries 21.12
+                        <br />
+                    </Bold>
+                    <Trans i18nKey={'database.samromur-queries'} t={t}>
+                        Þessi útgáfa gagna úr safni Samróms einblínir á
+                        fyrirspurnir. Útgáfan inniheldur 17.475 (20 klst.)
+                        staðfestar talupptökur á íslensku, fáanlegar bæði á{' '}
+                        <StyledLink
+                            target={'blank'}
+                            href={
+                                'https://repository.clarin.is/repository/xmlui/handle/20.500.12537/180'
+                            }
+                        >
+                            Clarin
+                        </StyledLink>{' '}
+                        og{' '}
+                        <StyledLink
+                            target={'blank'}
+                            href={'https://www.openslr.org/116/'}
+                        >
+                            OpenSLR
+                        </StyledLink>
+                        .
+                    </Trans>
+                </Dataset>
+
+                <span>{t('database.sign-up-for-updates')}</span>
             </AboutContainer>
         </AboutDatasetContainer>
     );

--- a/src/components/dataset/about.tsx
+++ b/src/components/dataset/about.tsx
@@ -110,9 +110,7 @@ export const AboutDataset: React.FunctionComponent<Props> = ({
                         talupptökur á íslensku, fáanlegar bæði ás{' '}
                         <StyledLink
                             target={'blank'}
-                            href={
-                                'https://repository.clarin.is/repository/xmlui/handle/20.500.12537/189'
-                            }
+                            href={'http://hdl.handle.net/20.500.12537/189'}
                         >
                             Clarin
                         </StyledLink>{' '}
@@ -138,9 +136,7 @@ export const AboutDataset: React.FunctionComponent<Props> = ({
                         bæði á{' '}
                         <StyledLink
                             target={'blank'}
-                            href={
-                                'https://repository.clarin.is/repository/xmlui/handle/20.500.12537/185'
-                            }
+                            href={'http://hdl.handle.net/20.500.12537/185'}
                         >
                             Clarin
                         </StyledLink>{' '}
@@ -165,9 +161,7 @@ export const AboutDataset: React.FunctionComponent<Props> = ({
                         staðfestar talupptökur á íslensku, fáanlegar bæði á{' '}
                         <StyledLink
                             target={'blank'}
-                            href={
-                                'https://repository.clarin.is/repository/xmlui/handle/20.500.12537/180'
-                            }
+                            href={'http://hdl.handle.net/20.500.12537/180'}
                         >
                             Clarin
                         </StyledLink>{' '}


### PR DESCRIPTION
Adds links and descriptions to the three available data sets.

Only adding links to clarin and openslr since it hasn't released on LDC yet.