### PR TITLE
removed ordering from H17-L2 sentence query

### DIFF
--- a/src/server/database/sentences.ts
+++ b/src/server/database/sentences.ts
@@ -218,7 +218,6 @@ export default class Sentences {
                     WHERE
                         clips.original_sentence_id = sentences.id
                 )
-            ORDER BY RAND()
             LIMIT ?
             `,
             [source, count]


### PR DESCRIPTION
@thdg 
Removing random ordering seems to speed up the query at least 5x when testing on my connection.

I'm guessing the random ordering had something to do with copyright for the main collection. That said, the l2 sentences already seemed to be randomised in the table.