### PR TITLE
workaround - fix formatting when opening l2 page by url.

### DIFF
--- a/src/components/subpages/l2-sign-in-hello.tsx
+++ b/src/components/subpages/l2-sign-in-hello.tsx
@@ -24,6 +24,18 @@ export const L2SignInHello: React.FC<Props> = (props) => {
         client: { isAuthenticated, username },
     } = useSelector((state: RootState) => state.user);
 
+    // State to handle dynamic rendering
+    const [clientRendered, setClientRendered] = React.useState(false);
+
+    React.useEffect(() => {
+        // Set client-rendered state after component mounts
+        setClientRendered(true);
+    }, []);
+
+    if (!clientRendered) {
+        return null;
+    }
+
     return (
         <L2Container>
             {!isAuthenticated && (


### PR DESCRIPTION
@thdg 
Makes formatting the same when navigating to l2 page from front page and when opening l2 page by url.